### PR TITLE
Add run scripts and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,56 @@
 # Bibbe-v1
 
-This repository contains the backend and frontend for the Bibbe project.
+This repository contains the backend API and React frontend for the Bibbe project.
 
-Environment variables are required for both applications. Example files are provided:
+## Setup
 
-- `driftai_project/Backend/.env.example`
-- `driftai_project/Frontend/.env.example`
+### 1. Configure environment variables
 
-Copy each example to `.env` in the same directory and fill in the real values before running the apps:
+Copy the example environment files and fill in real values:
 
 ```bash
 cp driftai_project/Backend/.env.example driftai_project/Backend/.env
 cp driftai_project/Frontend/.env.example driftai_project/Frontend/.env
 ```
 
-After copying, edit the new `.env` files to provide your database credentials, API keys and other settings.
+**Backend variables** (`driftai_project/Backend/.env`):
+- `PORT` – port number for the Express server
+- `DATABASE_URL` – connection string for PostgreSQL
+- `JWT_SECRET` – secret used for JSON Web Tokens
+- `OPENAI_API_KEY` – API key used for AI features
+- `FRONTEND_URL` – URL where the frontend is served
+
+**Frontend variables** (`driftai_project/Frontend/.env`):
+- `REACT_APP_API_URL` – URL of the backend server
+
+### 2. Install dependencies
+
+Install backend dependencies:
+
+```bash
+cd driftai_project
+npm install
+```
+
+Install frontend dependencies:
+
+```bash
+cd Frontend
+npm install
+```
+
+### 3. Running the apps
+
+Start the backend API (from `driftai_project`):
+
+```bash
+npm start
+```
+
+Start the React frontend (from `driftai_project/Frontend`):
+
+```bash
+npm start
+```
+
+The frontend will typically be available on `http://localhost:3000` and the backend on `http://localhost:3001` if using the default environment files.

--- a/driftai_project/package.json
+++ b/driftai_project/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node Backend/server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add `start` script to run backend server
- rewrite top-level README with setup and usage instructions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test -- -w 1` in `Frontend` *(shows no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c8df4db483318416dc62b493c282