### PR TITLE
Refactor backend modules

### DIFF
--- a/driftai_project/Backend/routes/analysis.js
+++ b/driftai_project/Backend/routes/analysis.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const TripletexService = require('../services/tripletex');
+const { FinancialAnalysisService, AIAnalysisService } = require('../services/analysis');
+
+module.exports = (pool, authenticate) => {
+  const router = express.Router();
+
+  router.get('/liquidity', authenticate, async (req, res) => {
+    try {
+      const { rows } = await pool.query('SELECT tripletex_token FROM users WHERE id = $1', [req.user.userId]);
+      const sessionToken = rows[0]?.tripletex_token;
+      if (!sessionToken) return res.status(400).json({ error: 'Tripletex not configured' });
+      const tripletex = new TripletexService(sessionToken);
+      const from = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+      const to = new Date().toISOString().split('T')[0];
+      const transactions = await tripletex.getTransactions(from, to);
+      const data = FinancialAnalysisService.calculateLiquidityBudget(transactions.values || []);
+      const aiInsight = await AIAnalysisService.generateInsight('liquidity', data);
+      await pool.query('INSERT INTO financial_data (user_id, data_type, data) VALUES ($1, $2, $3)', [req.user.userId, 'liquidity', JSON.stringify(data)]);
+      res.json({ data, aiInsight });
+    } catch (err) {
+      res.status(500).json({ error: 'Analysis failed' });
+    }
+  });
+
+  router.get('/cashflow', authenticate, async (req, res) => {
+    try {
+      const { rows } = await pool.query('SELECT tripletex_token FROM users WHERE id = $1', [req.user.userId]);
+      const sessionToken = rows[0]?.tripletex_token;
+      if (!sessionToken) return res.status(400).json({ error: 'Tripletex not configured' });
+      const tripletex = new TripletexService(sessionToken);
+      const from = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+      const to = new Date().toISOString().split('T')[0];
+      const transactions = await tripletex.getTransactions(from, to);
+      const data = FinancialAnalysisService.calculateCashFlowForecast(transactions.values || []);
+      const aiInsight = await AIAnalysisService.generateInsight('cashflow', data);
+      await pool.query('INSERT INTO financial_data (user_id, data_type, data) VALUES ($1, $2, $3)', [req.user.userId, 'cashflow', JSON.stringify(data)]);
+      res.json({ data, aiInsight });
+    } catch (err) {
+      res.status(500).json({ error: 'Analysis failed' });
+    }
+  });
+
+  router.get('/profitability', authenticate, async (req, res) => {
+    try {
+      const { rows } = await pool.query('SELECT tripletex_token FROM users WHERE id = $1', [req.user.userId]);
+      const sessionToken = rows[0]?.tripletex_token;
+      if (!sessionToken) return res.status(400).json({ error: 'Tripletex not configured' });
+      const tripletex = new TripletexService(sessionToken);
+      const from = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+      const to = new Date().toISOString().split('T')[0];
+      const transactions = await tripletex.getTransactions(from, to);
+      const data = FinancialAnalysisService.calculateProfitabilityAnalysis(transactions.values || []);
+      const aiInsight = await AIAnalysisService.generateInsight('profitability', data);
+      await pool.query('INSERT INTO financial_data (user_id, data_type, data) VALUES ($1, $2, $3)', [req.user.userId, 'profitability', JSON.stringify(data)]);
+      res.json({ data, aiInsight });
+    } catch (err) {
+      res.status(500).json({ error: 'Analysis failed' });
+    }
+  });
+
+  return router;
+};

--- a/driftai_project/Backend/routes/auth.js
+++ b/driftai_project/Backend/routes/auth.js
@@ -1,29 +1,58 @@
 const express = require('express');
-const router = express.Router();
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-const { Pool } = require('pg');
-require('dotenv').config();
+const TripletexService = require('../services/tripletex');
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
+module.exports = (pool, authenticate) => {
+  const router = express.Router();
 
-// Register new user
-router.post('/register', async (req, res) => {
-  const { email, password, company_name } = req.body;
-  try {
-    const hashedPassword = await bcrypt.hash(password, 10);
-    await pool.query(
-      'INSERT INTO users (email, password, company_name) VALUES ($1, $2, $3)',
-      [email, hashedPassword, company_name]
-    );
-    res.status(201).json({ message: 'User registered' });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Registration failed' });
-  }
-});
+  router.post('/register', async (req, res) => {
+    try {
+      const { email, password, companyName } = req.body;
+      if (!email || !password) {
+        return res.status(400).json({ error: 'Email and password required' });
+      }
+      const hashed = await bcrypt.hash(password, 10);
+      const result = await pool.query(
+        'INSERT INTO users (email, password_hash, company_name) VALUES ($1, $2, $3) RETURNING id, email, company_name',
+        [email, hashed, companyName]
+      );
+      const token = jwt.sign({ userId: result.rows[0].id }, process.env.JWT_SECRET, { expiresIn: '7d' });
+      res.json({ token, user: result.rows[0] });
+    } catch (err) {
+      if (err.code === '23505') {
+        return res.status(400).json({ error: 'Email already exists' });
+      }
+      res.status(500).json({ error: 'Registration failed' });
+    }
+  });
 
-module.exports = router;
+  router.post('/login', async (req, res) => {
+    try {
+      const { email, password } = req.body;
+      const result = await pool.query('SELECT * FROM users WHERE email = $1', [email]);
+      const user = result.rows[0];
+      if (!user || !await bcrypt.compare(password, user.password_hash)) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
+      const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET, { expiresIn: '7d' });
+      res.json({ token, user: { id: user.id, email: user.email, company_name: user.company_name } });
+    } catch (err) {
+      res.status(500).json({ error: 'Login failed' });
+    }
+  });
+
+  router.post('/tripletex/setup', authenticate, async (req, res) => {
+    try {
+      const { sessionToken } = req.body;
+      const tripletex = new TripletexService(sessionToken);
+      await tripletex.getAccounts();
+      await pool.query('UPDATE users SET tripletex_token = $1 WHERE id = $2', [sessionToken, req.user.userId]);
+      res.json({ success: true });
+    } catch (err) {
+      res.status(400).json({ error: 'Invalid Tripletex token' });
+    }
+  });
+
+  return router;
+};

--- a/driftai_project/Backend/server.js
+++ b/driftai_project/Backend/server.js
@@ -1,47 +1,34 @@
-// server.js - Hovedserverfil
 const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const jwt = require('jsonwebtoken');
-const bcrypt = require('bcrypt');
 const { Pool } = require('pg');
-const axios = require('axios');
 require('dotenv').config();
+
+const authRoutes = require('./routes/auth');
+const analysisRoutes = require('./routes/analysis');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-// Database connection
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
 });
 
-// Middleware
 app.use(helmet());
-app.use(cors({
-  origin: process.env.FRONTEND_URL || 'http://localhost:3000',
-  credentials: true
-}));
+app.use(cors({ origin: process.env.FRONTEND_URL || 'http://localhost:3000', credentials: true }));
 app.use(express.json({ limit: '10mb' }));
 
-// Rate limiting
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100 // limit each IP to 100 requests per windowMs
-});
+const limiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });
 app.use(limiter);
 
-// JWT middleware
+// JWT auth middleware
 const authenticateToken = (req, res, next) => {
   const authHeader = req.headers['authorization'];
   const token = authHeader && authHeader.split(' ')[1];
-
-  if (!token) {
-    return res.status(401).json({ error: 'Access token required' });
-  }
-
+  if (!token) return res.status(401).json({ error: 'Access token required' });
   jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
     if (err) return res.status(403).json({ error: 'Invalid token' });
     req.user = user;
@@ -49,173 +36,7 @@ const authenticateToken = (req, res, next) => {
   });
 };
 
-// Tripletex API Service
-class TripletexService {
-  constructor(sessionToken) {
-    this.sessionToken = sessionToken;
-    this.baseURL = 'https://api.tripletex.no/v2';
-  }
-
-  async makeRequest(endpoint, params = {}) {
-    try {
-      const response = await axios.get(`${this.baseURL}${endpoint}`, {
-        headers: {
-          'Authorization': `Basic ${Buffer.from(`0:${this.sessionToken}`).toString('base64')}`
-        },
-        params
-      });
-      return response.data;
-    } catch (error) {
-      console.error('Tripletex API Error:', error.response?.data || error.message);
-      throw new Error(`Tripletex API Error: ${error.response?.status || 'Unknown'}`);
-    }
-  }
-
-  async getAccounts() {
-    return await this.makeRequest('/ledger/account', { count: 1000 });
-  }
-
-  async getTransactions(fromDate, toDate) {
-    return await this.makeRequest('/ledger/voucher', {
-      dateFrom: fromDate,
-      dateTo: toDate,
-      count: 1000
-    });
-  }
-
-  async getCustomers() {
-    return await this.makeRequest('/customer', { count: 1000 });
-  }
-
-  async getSuppliers() {
-    return await this.makeRequest('/supplier', { count: 1000 });
-  }
-}
-
-// Financial Analysis Service
-class FinancialAnalysisService {
-  static calculateLiquidityBudget(transactions, weeks = 4) {
-    const startDate = new Date();
-    const budget = [];
-
-    // Analyser historiske data for å lage prognoser
-    const historicalIncome = transactions
-      .filter(t => t.amount > 0)
-      .reduce((sum, t) => sum + t.amount, 0) / transactions.length;
-    
-    const historicalExpenses = Math.abs(transactions
-      .filter(t => t.amount < 0)
-      .reduce((sum, t) => sum + t.amount, 0)) / transactions.length;
-
-    let accumulated = 250000; // Start likviditet (bør hentes fra bankkonto)
-
-    for (let i = 1; i <= weeks; i++) {
-      const weeklyIncome = historicalIncome * (0.9 + Math.random() * 0.2); // +/- 10% variasjon
-      const weeklyExpenses = historicalExpenses * (0.95 + Math.random() * 0.1);
-      const netto = weeklyIncome - weeklyExpenses;
-      accumulated += netto;
-
-      budget.push({
-        week: `Uke ${i}`,
-        inn: Math.round(weeklyIncome),
-        ut: Math.round(weeklyExpenses),
-        netto: Math.round(netto),
-        akkumulert: Math.round(accumulated)
-      });
-    }
-
-    return budget;
-  }
-
-  static calculateCashFlowForecast(transactions, months = 6) {
-    const currentDate = new Date();
-    const forecast = [];
-
-    // Beregn månedlig gjennomsnitt fra historiske data
-    const monthlyAverage = transactions.reduce((sum, t) => sum + t.amount, 0) / 3; // Siste 3 måneder
-
-    for (let i = 0; i < months; i++) {
-      const date = new Date(currentDate.getFullYear(), currentDate.getMonth() + i, 1);
-      const monthName = date.toLocaleDateString('nb-NO', { month: 'short' });
-      
-      let faktisk = null;
-      if (i < 3) { // Vi har faktiske data for de siste 3 månedene
-        faktisk = Math.round(monthlyAverage * (0.8 + Math.random() * 0.4));
-      }
-
-      const prognose = Math.round(monthlyAverage * (1 + (i * 0.05))); // 5% vekst per måned
-
-      forecast.push({
-        month: monthName,
-        faktisk,
-        prognose
-      });
-    }
-
-    return forecast;
-  }
-
-  static calculateProfitabilityAnalysis(transactions) {
-    // Forenklet P&L analyse
-    const revenue = transactions.filter(t => t.amount > 0).reduce((sum, t) => sum + t.amount, 0);
-    const expenses = Math.abs(transactions.filter(t => t.amount < 0).reduce((sum, t) => sum + t.amount, 0));
-
-    return [
-      { kategori: 'Salg', faktisk: Math.round(revenue), budsjett: Math.round(revenue * 0.94) },
-      { kategori: 'Lønn', faktisk: Math.round(-expenses * 0.4), budsjett: Math.round(-expenses * 0.38) },
-      { kategori: 'Husleie', faktisk: Math.round(-expenses * 0.15), budsjett: Math.round(-expenses * 0.15) },
-      { kategori: 'Markedsføring', faktisk: Math.round(-expenses * 0.1), budsjett: Math.round(-expenses * 0.12) },
-      { kategori: 'Andre kostnader', faktisk: Math.round(-expenses * 0.35), budsjett: Math.round(-expenses * 0.35) }
-    ];
-  }
-}
-
-// OpenAI Service for AI Analysis
-class AIAnalysisService {
-  static async generateInsight(type, data) {
-    try {
-      const prompts = {
-        liquidity: `Analyser følgende likviditetsdata og gi norsk forklaring og anbefalinger: ${JSON.stringify(data)}`,
-        cashflow: `Analyser kontantstrømdata og gi norsk analyse: ${JSON.stringify(data)}`,
-        profitability: `Analyser lønnsomhetsdata og gi norsk innsikt: ${JSON.stringify(data)}`
-      };
-
-      const response = await axios.post('https://api.openai.com/v1/chat/completions', {
-        model: 'gpt-4',
-        messages: [{
-          role: 'system',
-          content: 'Du er en ekspert regnskapsfører som forklarer økonomi på enkelt norsk til små bedrifter.'
-        }, {
-          role: 'user',
-          content: prompts[type]
-        }],
-        max_tokens: 300,
-        temperature: 0.7
-      }, {
-        headers: {
-          'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      return response.data.choices[0].message.content;
-    } catch (error) {
-      console.error('OpenAI API Error:', error.response?.data || error.message);
-      return this.getFallbackInsight(type);
-    }
-  }
-
-  static getFallbackInsight(type) {
-    const fallbacks = {
-      liquidity: 'Likviditeten ser stabil ut. Hold øye med kontantstrømmen og sørg for at kundene betaler i tide.',
-      cashflow: 'Kontantstrømmen viser positiv utvikling. Fortsett det gode arbeidet med salg og kostnadscontroll.',
-      profitability: 'Lønnsomheten er innenfor normale rammer. Vurder å optimalisere de største kostnadene.'
-    };
-    return fallbacks[type];
-  }
-}
-
-// Database schema setup
+// Create tables if they do not exist
 const initDatabase = async () => {
   try {
     await pool.query(`
@@ -227,7 +48,6 @@ const initDatabase = async () => {
         company_name VARCHAR(255),
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
-
       CREATE TABLE IF NOT EXISTS financial_data (
         id SERIAL PRIMARY KEY,
         user_id INTEGER REFERENCES users(id),
@@ -235,7 +55,6 @@ const initDatabase = async () => {
         data JSONB NOT NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
-
       CREATE TABLE IF NOT EXISTS ai_insights (
         id SERIAL PRIMARY KEY,
         user_id INTEGER REFERENCES users(id),
@@ -250,196 +69,21 @@ const initDatabase = async () => {
   }
 };
 
-// API Routes
+app.use('/api/auth', authRoutes(pool, authenticateToken));
+app.use('/api/analysis', analysisRoutes(pool, authenticateToken));
 
-// Auth routes
-app.post('/api/auth/register', async (req, res) => {
-  console.log('Registrering forsøkt med:', req.body);
-  try {
-    const { email, password, companyName } = req.body;
-    
-    if (!email || !password) {
-      return res.status(400).json({ error: 'Email and password required' });
-    }
-
-    const hashedPassword = await bcrypt.hash(password, 10);
-    
-    const result = await pool.query(
-      'INSERT INTO users (email, password_hash, company_name) VALUES ($1, $2, $3) RETURNING id, email, company_name',
-      [email, hashedPassword, companyName]
-    );
-
-    const token = jwt.sign({ userId: result.rows[0].id }, process.env.JWT_SECRET, { expiresIn: '7d' });
-    
-    res.json({ token, user: result.rows[0] });
-  } catch (error) {
-    if (error.code === '23505') {
-      return res.status(400).json({ error: 'Email already exists' });
-    }
-    res.status(500).json({ error: 'Registration failed' });
-  }
-});
-
-app.post('/api/auth/login', async (req, res) => {
-  try {
-    const { email, password } = req.body;
-    
-    const result = await pool.query('SELECT * FROM users WHERE email = $1', [email]);
-    const user = result.rows[0];
-
-    if (!user || !await bcrypt.compare(password, user.password_hash)) {
-      return res.status(401).json({ error: 'Invalid credentials' });
-    }
-
-    const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET, { expiresIn: '7d' });
-    
-    res.json({ 
-      token, 
-      user: { 
-        id: user.id, 
-        email: user.email, 
-        company_name: user.company_name 
-      } 
-    });
-  } catch (error) {
-    res.status(500).json({ error: 'Login failed' });
-  }
-});
-
-// Tripletex setup
-app.post('/api/tripletex/setup', authenticateToken, async (req, res) => {
-  try {
-    const { sessionToken } = req.body;
-    
-    // Test connection
-    const tripletex = new TripletexService(sessionToken);
-    await tripletex.getAccounts();
-    
-    // Save token
-    await pool.query(
-      'UPDATE users SET tripletex_token = $1 WHERE id = $2',
-      [sessionToken, req.user.userId]
-    );
-
-    res.json({ success: true });
-  } catch (error) {
-    res.status(400).json({ error: 'Invalid Tripletex token' });
-  }
-});
-
-// Financial analysis endpoints
-app.get('/api/analysis/liquidity', authenticateToken, async (req, res) => {
-  try {
-    const userResult = await pool.query('SELECT tripletex_token FROM users WHERE id = $1', [req.user.userId]);
-    const sessionToken = userResult.rows[0]?.tripletex_token;
-
-    if (!sessionToken) {
-      return res.status(400).json({ error: 'Tripletex not configured' });
-    }
-
-    const tripletex = new TripletexService(sessionToken);
-    const fromDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-    const toDate = new Date().toISOString().split('T')[0];
-    
-    const transactions = await tripletex.getTransactions(fromDate, toDate);
-    const liquidityBudget = FinancialAnalysisService.calculateLiquidityBudget(transactions.values || []);
-    
-    // Get AI insight
-    const aiInsight = await AIAnalysisService.generateInsight('liquidity', liquidityBudget);
-    
-    // Cache results
-    await pool.query(
-      'INSERT INTO financial_data (user_id, data_type, data) VALUES ($1, $2, $3)',
-      [req.user.userId, 'liquidity', JSON.stringify(liquidityBudget)]
-    );
-
-    res.json({ data: liquidityBudget, aiInsight });
-  } catch (error) {
-    console.error('Liquidity analysis error:', error);
-    res.status(500).json({ error: 'Analysis failed' });
-  }
-});
-
-app.get('/api/analysis/cashflow', authenticateToken, async (req, res) => {
-  try {
-    const userResult = await pool.query('SELECT tripletex_token FROM users WHERE id = $1', [req.user.userId]);
-    const sessionToken = userResult.rows[0]?.tripletex_token;
-
-    if (!sessionToken) {
-      return res.status(400).json({ error: 'Tripletex not configured' });
-    }
-
-    const tripletex = new TripletexService(sessionToken);
-    const fromDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-    const toDate = new Date().toISOString().split('T')[0];
-    
-    const transactions = await tripletex.getTransactions(fromDate, toDate);
-    const cashFlowForecast = FinancialAnalysisService.calculateCashFlowForecast(transactions.values || []);
-    
-    const aiInsight = await AIAnalysisService.generateInsight('cashflow', cashFlowForecast);
-    
-    await pool.query(
-      'INSERT INTO financial_data (user_id, data_type, data) VALUES ($1, $2, $3)',
-      [req.user.userId, 'cashflow', JSON.stringify(cashFlowForecast)]
-    );
-
-    res.json({ data: cashFlowForecast, aiInsight });
-  } catch (error) {
-    console.error('Cashflow analysis error:', error);
-    res.status(500).json({ error: 'Analysis failed' });
-  }
-});
-
-app.get('/api/analysis/profitability', authenticateToken, async (req, res) => {
-  try {
-    const userResult = await pool.query('SELECT tripletex_token FROM users WHERE id = $1', [req.user.userId]);
-    const sessionToken = userResult.rows[0]?.tripletex_token;
-
-    if (!sessionToken) {
-      return res.status(400).json({ error: 'Tripletex not configured' });
-    }
-
-    const tripletex = new TripletexService(sessionToken);
-    const fromDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-    const toDate = new Date().toISOString().split('T')[0];
-    
-    const transactions = await tripletex.getTransactions(fromDate, toDate);
-    const profitabilityAnalysis = FinancialAnalysisService.calculateProfitabilityAnalysis(transactions.values || []);
-    
-    const aiInsight = await AIAnalysisService.generateInsight('profitability', profitabilityAnalysis);
-    
-    await pool.query(
-      'INSERT INTO financial_data (user_id, data_type, data) VALUES ($1, $2, $3)',
-      [req.user.userId, 'profitability', JSON.stringify(profitabilityAnalysis)]
-    );
-
-    res.json({ data: profitabilityAnalysis, aiInsight });
-  } catch (error) {
-    console.error('Profitability analysis error:', error);
-    res.status(500).json({ error: 'Analysis failed' });
-  }
-});
-
-// Health check
 app.get('/health', (req, res) => {
   res.json({ status: 'OK', timestamp: new Date().toISOString() });
 });
 
-// routes
-app.use('/api/auth', require('./routes/auth'));
-
-// Error handling middleware
 app.use((error, req, res, next) => {
   console.error(error);
   res.status(500).json({ error: 'Internal server error' });
 });
 
-// Start server
 const startServer = async () => {
   await initDatabase();
-  app.listen(PORT, () => {
-    console.log(`Server running on port ${PORT}`);
-  });
+  app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
 };
 
 startServer().catch(console.error);

--- a/driftai_project/Backend/services/analysis.js
+++ b/driftai_project/Backend/services/analysis.js
@@ -1,0 +1,96 @@
+const axios = require('axios');
+
+class FinancialAnalysisService {
+  static calculateLiquidityBudget(transactions, weeks = 4) {
+    const budget = [];
+    const historicalIncome = transactions
+      .filter(t => t.amount > 0)
+      .reduce((s, t) => s + t.amount, 0) / transactions.length;
+    const historicalExpenses = Math.abs(transactions
+      .filter(t => t.amount < 0)
+      .reduce((s, t) => s + t.amount, 0)) / transactions.length;
+    let accumulated = 250000;
+    for (let i = 1; i <= weeks; i++) {
+      const weeklyIncome = historicalIncome * (0.9 + Math.random() * 0.2);
+      const weeklyExpenses = historicalExpenses * (0.95 + Math.random() * 0.1);
+      const netto = weeklyIncome - weeklyExpenses;
+      accumulated += netto;
+      budget.push({
+        week: `Uke ${i}`,
+        inn: Math.round(weeklyIncome),
+        ut: Math.round(weeklyExpenses),
+        netto: Math.round(netto),
+        akkumulert: Math.round(accumulated)
+      });
+    }
+    return budget;
+  }
+
+  static calculateCashFlowForecast(transactions, months = 6) {
+    const forecast = [];
+    const monthlyAverage = transactions.reduce((s, t) => s + t.amount, 0) / 3;
+    const currentDate = new Date();
+    for (let i = 0; i < months; i++) {
+      const date = new Date(currentDate.getFullYear(), currentDate.getMonth() + i, 1);
+      const monthName = date.toLocaleDateString('nb-NO', { month: 'short' });
+      let faktisk = null;
+      if (i < 3) {
+        faktisk = Math.round(monthlyAverage * (0.8 + Math.random() * 0.4));
+      }
+      const prognose = Math.round(monthlyAverage * (1 + (i * 0.05)));
+      forecast.push({ month: monthName, faktisk, prognose });
+    }
+    return forecast;
+  }
+
+  static calculateProfitabilityAnalysis(transactions) {
+    const revenue = transactions.filter(t => t.amount > 0)
+      .reduce((s, t) => s + t.amount, 0);
+    const expenses = Math.abs(transactions.filter(t => t.amount < 0)
+      .reduce((s, t) => s + t.amount, 0));
+    return [
+      { kategori: 'Salg', faktisk: Math.round(revenue), budsjett: Math.round(revenue * 0.94) },
+      { kategori: 'L\u00f8nn', faktisk: Math.round(-expenses * 0.4), budsjett: Math.round(-expenses * 0.38) },
+      { kategori: 'Husleie', faktisk: Math.round(-expenses * 0.15), budsjett: Math.round(-expenses * 0.15) },
+      { kategori: 'Markedsf\u00f8ring', faktisk: Math.round(-expenses * 0.1), budsjett: Math.round(-expenses * 0.12) },
+      { kategori: 'Andre kostnader', faktisk: Math.round(-expenses * 0.35), budsjett: Math.round(-expenses * 0.35) }
+    ];
+  }
+}
+
+class AIAnalysisService {
+  static async generateInsight(type, data) {
+    const prompts = {
+      liquidity: `Analyser f\u00f8lgende likviditetsdata og gi norsk forklaring: ${JSON.stringify(data)}`,
+      cashflow: `Analyser kontantstr\u00f8mdata og gi norsk analyse: ${JSON.stringify(data)}`,
+      profitability: `Analyser l\u00f8nnsomhetsdata og gi norsk innsikt: ${JSON.stringify(data)}`
+    };
+    try {
+      const response = await axios.post('https://api.openai.com/v1/chat/completions', {
+        model: 'gpt-4',
+        messages: [{ role: 'system', content: 'Du er en ekspert regnskapsf\u00f8rer.' }, { role: 'user', content: prompts[type] }],
+        max_tokens: 300,
+        temperature: 0.7
+      }, {
+        headers: {
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json'
+        }
+      });
+      return response.data.choices[0].message.content;
+    } catch (error) {
+      return this.getFallbackInsight(type);
+    }
+  }
+
+  static getFallbackInsight(type) {
+    const fallbacks = {
+      liquidity: 'Likviditeten ser stabil ut.',
+      cashflow: 'Kontantstr\u00f8mmen viser positiv utvikling.',
+      profitability: 'L\u00f8nnsomheten er innenfor normale rammer.'
+    };
+    return fallbacks[type];
+  }
+}
+
+module.exports = { FinancialAnalysisService, AIAnalysisService };

--- a/driftai_project/Backend/services/tripletex.js
+++ b/driftai_project/Backend/services/tripletex.js
@@ -1,0 +1,40 @@
+const axios = require('axios');
+
+class TripletexService {
+  constructor(sessionToken) {
+    this.sessionToken = sessionToken;
+    this.baseURL = 'https://api.tripletex.no/v2';
+  }
+
+  async makeRequest(endpoint, params = {}) {
+    const response = await axios.get(`${this.baseURL}${endpoint}`, {
+      headers: {
+        Authorization: `Basic ${Buffer.from(`0:${this.sessionToken}`).toString('base64')}`
+      },
+      params
+    });
+    return response.data;
+  }
+
+  async getAccounts() {
+    return this.makeRequest('/ledger/account', { count: 1000 });
+  }
+
+  async getTransactions(fromDate, toDate) {
+    return this.makeRequest('/ledger/voucher', {
+      dateFrom: fromDate,
+      dateTo: toDate,
+      count: 1000
+    });
+  }
+
+  async getCustomers() {
+    return this.makeRequest('/customer', { count: 1000 });
+  }
+
+  async getSuppliers() {
+    return this.makeRequest('/supplier', { count: 1000 });
+  }
+}
+
+module.exports = TripletexService;


### PR DESCRIPTION
## Summary
- move Tripletex API client and analysis helpers to `services`
- rewrite auth and analysis routes using these services
- slim down `server.js` to just middleware setup and route mounting

## Testing
- `npm test --prefix driftai_project` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859c8e04ee883318d90285b743afe34